### PR TITLE
Remove right sidebar from research page

### DIFF
--- a/page-templates/page-research.php
+++ b/page-templates/page-research.php
@@ -76,13 +76,6 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 		</div><!-- #primary -->
 
-		<!-- Do the right sidebar check -->
-		<?php if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) : ?>
-
-			<?php get_sidebar( 'right' ); ?>
-
-		<?php endif; ?>
-
 	</div><!-- .row -->
 
 </div><!-- Container end -->


### PR DESCRIPTION
This sidebar widget is being used to present a table of contents on actual report pages, leading to an arbitrary table of contents showing on /research